### PR TITLE
Remove the bundler with clean, it seems to work fine without on later releases of bundler

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -38,9 +38,7 @@ def bootstrap name = nil
     Dir.chdir(dir) do
       subtitle "Bootstrapping #{dir}"
       if has_rake_task?('bootstrap')
-        Bundler.with_clean_env do
-          sh "rake --no-search bootstrap"
-        end
+        sh "rake --no-search bootstrap"
       end
     end
   end
@@ -139,9 +137,7 @@ begin
     if name = args.name
       bootstrap(name)
     else
-      Bundler.with_clean_env do
-        puts `bundle install`
-      end
+      puts `bundle install`
     end
   end
 


### PR DESCRIPTION
I couldn't use any rake commands because of errors like:

![screen shot 2016-12-01 at 09 53 00](https://cloud.githubusercontent.com/assets/49038/20789366/fafc3000-b7ab-11e6-9a47-0a5eef654537.png)

Removing the `with_clean_env` fixed it 👍 