### PR TITLE
Fix regexp

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -340,7 +340,7 @@ def fetch_repos
     repos.concat(JSON.parse(response))
 
     link = Array(file.meta['link']).first
-    if match = link.match(/<(.*)>; rel="next"/)
+    if match = link.match(/<([^<]*)>; rel="next"/)
       url = match.captures.first
     else
       break


### PR DESCRIPTION
Regexp for getting available repositories' urls doesn't work correctly if account 'cocoapods' has more then 2 pages of repositories. Consequently rake task fails with error. Change `.*` to `[^<]*` fix this problem.